### PR TITLE
Update blah2 images to v0.2.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   blah2:
     restart: always
-    image: ghcr.io/offworldlabs/blah2:v0.2.6
+    image: ghcr.io/offworldlabs/blah2:v0.2.8
     tty: true
     depends_on:
       config-merger:
@@ -43,7 +43,7 @@ services:
 
   blah2_web:
     restart: always
-    image: ghcr.io/offworldlabs/blah2-web:v0.2.6
+    image: ghcr.io/offworldlabs/blah2-web:v0.2.8
     ports:
       - 49152:80
     networks:
@@ -52,7 +52,7 @@ services:
 
   blah2_api:
     restart: always
-    image: ghcr.io/offworldlabs/blah2-api:v0.2.6
+    image: ghcr.io/offworldlabs/blah2-api:v0.2.8
     depends_on:
       config-merger:
         condition: service_completed_successfully
@@ -65,7 +65,7 @@ services:
 
   blah2_host:
     restart: always
-    image: ghcr.io/offworldlabs/blah2-host:v0.2.6
+    image: ghcr.io/offworldlabs/blah2-host:v0.2.8
     ports:
       - "8080:80"
     networks:


### PR DESCRIPTION
## Summary
- Updates all blah2 container images from v0.2.6 to v0.2.8

## Changes in blah2 v0.2.8
- Reduces frontend polling interval from 100ms to 1000ms
- Prevents ERR_INSUFFICIENT_RESOURCES browser errors when server is under load

## Images Updated
- blah2: v0.2.6 -> v0.2.8
- blah2-web: v0.2.6 -> v0.2.8
- blah2-api: v0.2.6 -> v0.2.8
- blah2-host: v0.2.6 -> v0.2.8

## Next Steps
After merging, tag a new release (e.g., v0.3.0) to trigger the Mender artifact build.

Generated with Claude Code