### PR TITLE
Add staging environment for x86_64 testing

### DIFF
--- a/staging/.gitignore
+++ b/staging/.gitignore
@@ -1,0 +1,17 @@
+# Generated config
+config/config.yml
+
+# Environment overrides
+.env.staging.local
+
+# Data directories
+data/
+
+# Manifests directory (for Mender simulation)
+manifests/
+
+# Backup files
+*.bak
+
+# Docker volumes
+volumes/

--- a/staging/QUICKSTART.md
+++ b/staging/QUICKSTART.md
@@ -1,0 +1,141 @@
+# Staging Quick Reference
+
+## Initial Setup (One Time)
+
+```bash
+cd retina-node/staging
+./setup.sh                # Install QEMU, create directories
+./merge-config.sh         # Generate config.yml
+```
+
+## Start Services
+
+```bash
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d
+```
+
+## Test New Version
+
+```bash
+# Quick test of specific version
+./test-version.sh blah2 v0.3.5
+./test-version.sh adsb2dd v0.1.4
+
+# Or manually:
+nano .env.staging         # Update version
+docker compose -f docker-compose.staging.yml --env-file .env.staging pull
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --force-recreate
+```
+
+## Check Status
+
+```bash
+# Service status
+docker compose -f docker-compose.staging.yml ps
+
+# Recent logs
+docker compose -f docker-compose.staging.yml logs -f --tail=50
+
+# Specific service logs
+docker compose -f docker-compose.staging.yml logs -f blah2_api
+
+# Run smoke tests
+./smoke-test.sh
+```
+
+## Access Services
+
+- blah2 UI: http://localhost:49152
+- tar1090: http://localhost:8078
+- adsb2dd: http://localhost:49155/api
+- blah2 API: http://localhost:3000/api/config
+
+## Quick Health Checks
+
+```bash
+# Check containers running
+docker compose -f docker-compose.staging.yml ps
+
+# Check tar1090 receiving aircraft
+curl -s http://localhost:8078/data/aircraft.json | jq '.aircraft | length'
+
+# Check adsb2dd processing
+curl -s http://localhost:49155/api | jq 'keys | length'
+
+# Check for errors
+docker compose -f docker-compose.staging.yml logs --since 5m | grep -i error
+```
+
+## Configuration Changes
+
+```bash
+nano config/user.yml      # Edit staging config
+./merge-config.sh         # Regenerate config.yml
+docker compose -f docker-compose.staging.yml restart
+```
+
+## Stop/Cleanup
+
+```bash
+# Stop services
+docker compose -f docker-compose.staging.yml down
+
+# Stop and remove volumes
+docker compose -f docker-compose.staging.yml down -v
+
+# Remove all staging data
+rm -rf data/ config/config.yml
+```
+
+## Troubleshooting
+
+```bash
+# Check ARM64 support
+docker run --rm --platform linux/arm64 arm64v8/alpine uname -m
+
+# Restart QEMU support
+./setup.sh
+
+# Force recreate all services
+docker compose -f docker-compose.staging.yml up -d --force-recreate
+
+# Remove and rebuild everything
+docker compose -f docker-compose.staging.yml down -v
+docker system prune -a
+./setup.sh
+./merge-config.sh
+docker compose -f docker-compose.staging.yml up -d
+```
+
+## Common Workflow
+
+**Daily testing cycle**:
+```bash
+# 1. Update version
+./test-version.sh blah2 v0.3.5
+
+# 2. Run smoke tests
+./smoke-test.sh
+
+# 3. Visual testing (open in browser)
+open http://localhost:49152
+open http://localhost:8078
+
+# 4. Check logs
+docker compose -f docker-compose.staging.yml logs -f
+```
+
+**Before deploying to production**:
+```bash
+# 1. Test in staging
+./test-version.sh blah2 v0.3.5
+./smoke-test.sh
+
+# 2. Visual verification
+# Open web UIs and verify behavior
+
+# 3. Let it run for a few hours
+# Monitor logs for errors
+
+# 4. If stable, proceed to production deployment via Mender
+```

--- a/staging/README.md
+++ b/staging/README.md
@@ -1,0 +1,406 @@
+# Retina Node Staging Environment
+
+Staging environment for testing retina-node deployments before production. Runs ARM64 containers on x86_64 hosts using QEMU emulation.
+
+## Overview
+
+**Purpose**: Catch integration bugs and configuration errors before deploying to production Raspberry Pi nodes.
+
+**Architecture**:
+- x86_64 Hetzner server running Ubuntu
+- QEMU userspace emulation for ARM64 containers
+- Services pull real data from radar3.retnode.com
+- Tests: blah2 API/web, tar1090, adsb2dd (blah2 core disabled - requires SDR hardware)
+
+**What This Tests**:
+- ✅ ARM64 container compatibility
+- ✅ Service integration and networking
+- ✅ Configuration changes
+- ✅ Web interfaces and APIs
+- ✅ Data pipeline: ADS-B → tar1090 → adsb2dd
+- ❌ Actual SDR radar processing (requires hardware)
+
+**What This Doesn't Test**:
+- Mender deployment flow (see "Full Mender Testing" section)
+- Hardware-specific issues (SDR drivers, USB)
+- Performance under load
+
+## Quick Start
+
+```bash
+# 1. Clone repo and navigate to staging
+cd retina-node/staging
+
+# 2. Run setup script
+chmod +x setup.sh
+./setup.sh
+
+# 3. Merge configuration
+chmod +x merge-config.sh
+./merge-config.sh
+
+# 4. Start services
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d
+
+# 5. Verify
+docker compose -f docker-compose.staging.yml ps
+curl http://localhost:8078  # tar1090
+curl http://localhost:49152  # blah2 web
+```
+
+## Detailed Setup
+
+### Prerequisites
+
+- x86_64 Linux server (Ubuntu 22.04+ recommended)
+- Docker and Docker Compose installed
+- Minimum 4GB RAM, 20GB disk
+- Python 3 with PyYAML (`pip3 install pyyaml`)
+- Network access to radar3.retnode.com
+
+### Step 1: Install QEMU Support
+
+Run the setup script to install QEMU and register ARM64 binary formats:
+
+```bash
+cd retina-node/staging
+chmod +x setup.sh
+./setup.sh
+```
+
+This installs:
+- `qemu-user-static` - ARM64 userspace emulation
+- `binfmt-support` - Binary format handlers
+- Registers ARM64 support with Docker
+
+**Verify ARM64 works**:
+```bash
+docker run --rm --platform linux/arm64 arm64v8/alpine uname -m
+# Should output: aarch64
+```
+
+### Step 2: Configure Environment
+
+Edit `.env.staging` to set package versions to test:
+
+```bash
+nano .env.staging
+```
+
+Key variables:
+```bash
+# Package versions to test
+BLAH2_V=v0.3.5        # Update this when testing new blah2 builds
+ADSB2DD_V=v0.1.4      # Update this when testing new adsb2dd builds
+TAR1090_V=v0.2.0
+
+# Service ports (defaults work for single staging instance)
+BLAH2_WEB_PORT=49152
+TAR1090_PORT=8078
+
+# Location (radar3 - already configured)
+RECEIVER_LAT=33.939182
+RECEIVER_LON=-84.65191
+RECEIVER_ALT=320
+
+# ADS-B feed from radar3
+READSB_NET_CONNECTOR=radar3.retnode.com,30005,beast_in
+```
+
+### Step 3: Merge Configuration
+
+Generate the merged config file:
+
+```bash
+chmod +x merge-config.sh
+./merge-config.sh
+```
+
+This creates `config/config.yml` by merging:
+- `../config/default.yml` (base defaults)
+- `config/user.yml` (staging overrides)
+- `../config/forced.yml` (forced values)
+
+**Optional**: Edit `config/user.yml` to override specific settings.
+
+### Step 4: Start Services
+
+```bash
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d
+```
+
+**First run takes 5-10 minutes** - Docker pulls ARM64 images and QEMU emulates them.
+
+**Check status**:
+```bash
+docker compose -f docker-compose.staging.yml ps
+docker compose -f docker-compose.staging.yml logs -f
+```
+
+### Step 5: Verify Services
+
+**Web Interfaces**:
+- blah2: http://localhost:49152
+- tar1090: http://localhost:8078
+- adsb2dd API: http://localhost:49155/api
+
+**Health Checks**:
+```bash
+# Check tar1090 is receiving ADS-B
+curl -s http://localhost:8078/data/aircraft.json | jq '.aircraft | length'
+
+# Check adsb2dd is processing
+curl -s http://localhost:49155/api | jq 'keys | length'
+
+# Check all containers running
+docker compose -f docker-compose.staging.yml ps
+```
+
+**Expected Output**:
+- tar1090 shows aircraft from radar3's area (Georgia)
+- adsb2dd returns delay-Doppler data
+- blah2 web UI loads (but shows no radar data - normal without SDR)
+
+## Testing Workflow
+
+### Testing New Package Versions
+
+**Scenario**: You've built new blah2 v0.3.5 and want to test it before production.
+
+```bash
+# 1. Update version in .env.staging
+nano .env.staging
+# Change: BLAH2_V=v0.3.5
+
+# 2. Pull new images and restart
+docker compose -f docker-compose.staging.yml --env-file .env.staging pull
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --force-recreate
+
+# 3. Watch for errors
+docker compose -f docker-compose.staging.yml logs -f blah2_api blah2_web
+
+# 4. Verify web interface
+curl http://localhost:49152
+# Or open in browser and click around
+
+# 5. Check for breaking changes
+docker compose -f docker-compose.staging.yml exec blah2_api node --version
+docker compose -f docker-compose.staging.yml logs blah2_api | grep -i error
+```
+
+### Testing Configuration Changes
+
+**Scenario**: You've modified default.yml or forced.yml.
+
+```bash
+# 1. Merge updated config
+./merge-config.sh
+
+# 2. Restart services to pick up config
+docker compose -f docker-compose.staging.yml --env-file .env.staging restart
+
+# 3. Verify config applied
+docker compose -f docker-compose.staging.yml exec blah2_api cat /usr/src/app/config/config.yml
+```
+
+### Visual Testing with Browser
+
+For UI changes, use Claude in Chrome or manual testing:
+
+```bash
+# Start services if not running
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d
+
+# Get your server's public IP
+curl -4 ifconfig.me
+
+# Open in browser:
+# http://<server-ip>:49152  (blah2)
+# http://<server-ip>:8078   (tar1090)
+```
+
+**Firewall Note**: Open ports 49152, 8078, 49155 if testing remotely.
+
+### Automated Integration Tests
+
+Basic smoke tests:
+
+```bash
+#!/bin/bash
+# save as test-staging.sh
+
+set -e
+
+echo "Running staging integration tests..."
+
+# Test tar1090
+echo "✓ Testing tar1090..."
+AIRCRAFT=$(curl -s http://localhost:8078/data/aircraft.json | jq '.aircraft | length')
+if [ "$AIRCRAFT" -gt 0 ]; then
+  echo "  ✓ Receiving $AIRCRAFT aircraft"
+else
+  echo "  ⚠ No aircraft received (might be normal if radar3 area is empty)"
+fi
+
+# Test adsb2dd
+echo "✓ Testing adsb2dd..."
+TARGETS=$(curl -s http://localhost:49155/api | jq 'keys | length')
+echo "  ✓ Processing $TARGETS targets"
+
+# Test blah2 API
+echo "✓ Testing blah2 API..."
+curl -f http://localhost:3000/api/config >/dev/null
+echo "  ✓ API responding"
+
+# Test blah2 web
+echo "✓ Testing blah2 web..."
+curl -f http://localhost:49152 >/dev/null
+echo "  ✓ Web UI responding"
+
+echo ""
+echo "All tests passed! ✓"
+```
+
+## Common Issues
+
+### Services Won't Start
+
+**Check ARM64 support**:
+```bash
+docker run --rm --platform linux/arm64 arm64v8/alpine uname -m
+```
+
+If this fails, re-run setup:
+```bash
+./setup.sh
+```
+
+### Slow Performance
+
+ARM64 emulation is inherently slower than native. Typical performance:
+- Container startup: 2-5x slower
+- Runtime: 1.5-3x slower
+- Acceptable for testing, not for production loads
+
+**Improve performance**:
+- Use server with more CPU cores
+- Reduce number of concurrent containers
+- Use caching for frequent rebuilds
+
+### Can't Pull Images
+
+**Authentication required**:
+```bash
+# Login to GitHub Container Registry
+echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
+```
+
+### Port Conflicts
+
+If ports 8078, 49152, 49155 are in use:
+
+```bash
+# Edit .env.staging to use different ports
+nano .env.staging
+
+# Example:
+BLAH2_WEB_PORT=59152
+TAR1090_PORT=58078
+```
+
+### tar1090 Shows No Aircraft
+
+**Check ADS-B feed**:
+```bash
+# Verify connectivity to radar3
+curl -v telnet://radar3.retnode.com:30005
+
+# Check tar1090 logs
+docker compose -f docker-compose.staging.yml logs tar1090 | grep -i beast
+```
+
+If radar3 feed is down, enable adsb.lol fallback in `.env.staging`:
+```bash
+ADSBLOL_ENABLED=true
+ADSBLOL_RADIUS=40
+```
+
+## Full Mender Testing (Advanced)
+
+For testing the complete Mender deployment flow, use a full ARM64 VM:
+
+### Option B: QEMU ARM64 VM
+
+**When to use**: Before deploying to production to test Mender artifact deployment.
+
+**Setup** (brief - requires more expertise):
+```bash
+# Install QEMU system emulation
+sudo apt install qemu-system-aarch64
+
+# Create ARM64 VM with owl-os
+# Follow owl-os installation guide
+# Configure Mender client to point to your Mender server
+
+# Deploy artifact via Mender dashboard
+# Verify deployment succeeds
+```
+
+**Pros**:
+- Tests full Mender deployment flow
+- Identical to production environment
+
+**Cons**:
+- Slow (full system emulation)
+- Complex setup (requires VM management)
+- Use sparingly (once before major releases)
+
+**Recommendation**: Use Docker staging (Option A) for daily testing, VM testing (Option B) only for critical pre-production validation.
+
+## Maintenance
+
+### Updating Staging
+
+Pull latest retina-node changes:
+```bash
+cd retina-node
+git pull
+cd staging
+./merge-config.sh
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --force-recreate
+```
+
+### Cleaning Up
+
+Remove all staging containers and volumes:
+```bash
+docker compose -f docker-compose.staging.yml down -v
+rm -rf data/ config/config.yml
+```
+
+### Disk Space
+
+Check Docker disk usage:
+```bash
+docker system df
+docker image prune -a  # Remove unused images
+```
+
+## Next Steps
+
+After staging tests pass:
+
+1. **Tag new version** in source repos (blah2-arm, adsb2dd)
+2. **GitHub Actions builds** Mender artifact
+3. **Download artifact** from GitHub releases
+4. **Upload to Mender dashboard**
+5. **Deploy to production** device group
+6. **Monitor deployment** via Mender
+7. **Verify production** node health
+
+## References
+
+- [retina-node README](../README.md) - Main documentation
+- [STANDALONE.md](../STANDALONE.md) - Standalone deployment
+- [owl-os](https://github.com/offworldlabs/owl-os) - Base OS for production nodes
+- [Mender Documentation](https://docs.mender.io/) - OTA deployment platform

--- a/staging/config/user.yml
+++ b/staging/config/user.yml
@@ -1,0 +1,33 @@
+# Staging environment configuration
+# Uses radar3.retnode.com location and pulls ADS-B data from production
+
+location:
+  rx:
+    latitude: 33.939182
+    longitude: -84.65191
+    altitude: 320
+    name: "radar3-rx (Wilderness)"
+  tx:
+    latitude: 33.939182
+    longitude: -84.331844
+    altitude: 650
+    name: "WXIA HDTV"
+
+network:
+  node_id: "staging-node"
+
+  # Services communicate via Docker network
+  tracker_forward:
+    enabled: false
+
+truth:
+  adsb:
+    enabled: true
+    tar1090: 'tar1090:80'  # Internal Docker network
+    adsb2dd: 'adsb2dd:49155'  # Internal Docker network
+    delay_tolerance: 2.0
+    doppler_tolerance: 5.0
+
+# tar1090 pulls ADS-B from radar3's public feed
+# This is configured via READSB_NET_CONNECTOR env var in docker-compose
+# Format: radar3.retnode.com,30005,beast_in

--- a/staging/docker-compose.staging.yml
+++ b/staging/docker-compose.staging.yml
@@ -1,0 +1,125 @@
+# Staging Docker Compose - x86_64 host with ARM64 emulation
+# Tests web services, tar1090, and adsb2dd using data from radar3.retnode.com
+# blah2 core disabled (requires SDR hardware)
+
+networks:
+  blah2:
+    driver: bridge
+
+services:
+
+  config-merger:
+    restart: "no"
+    platform: linux/arm64/v8
+    image: ghcr.io/offworldlabs/retina-config-merger:${CONFIG_MERGER_V:-v0.3.3}
+    volumes:
+      - ${CONFIG_DIR:-./config}:/data/retina-node/config
+      - ${MENDER_APP_DIR:-./manifests}:/data/mender-app
+      - ${MENDER_DATA_DIR:-./manifests}:/data/mender:ro
+    container_name: retina-config-merger
+    command: >
+      sh -c "
+        if [ '${SKIP_CONFIG_MERGER:-false}' = 'true' ]; then
+          echo 'Config merger skipped (standalone mode)';
+          exit 0;
+        fi;
+        python3 /usr/local/bin/merge_config.py /config/defaults /data/retina-node/config/user.yml /data/retina-node/config/config.yml
+      "
+
+  # blah2 core DISABLED in staging (requires SDR hardware)
+  # To test blah2, use replay mode with IQ files from radar3
+
+  blah2_web:
+    restart: always
+    platform: linux/arm64/v8
+    image: ghcr.io/offworldlabs/blah2-web:${BLAH2_V:-v0.3.4}
+    ports:
+      - "${BLAH2_WEB_PORT:-49152}:80"
+    networks:
+      - blah2
+    container_name: blah2-web
+
+  blah2_api:
+    restart: always
+    platform: linux/arm64/v8
+    image: ghcr.io/offworldlabs/blah2-api:${BLAH2_V:-v0.3.4}
+    depends_on:
+      config-merger:
+        condition: service_completed_successfully
+    volumes:
+      - ${CONFIG_DIR:-./config}:/usr/src/app/config:ro
+    ports:
+      - "3000:3000"  # API port
+      - "3001:3001"  # Map port
+      - "3002:3002"  # Detection port
+      - "3003:3003"  # Track port
+    networks:
+      - blah2
+    command: node server.js /usr/src/app/config/config.yml
+    container_name: blah2-api
+
+  blah2_host:
+    restart: always
+    platform: linux/arm64/v8
+    image: ghcr.io/offworldlabs/blah2-host:${BLAH2_V:-v0.3.4}
+    ports:
+      - "${BLAH2_HOST_PORT:-8080}:80"
+    networks:
+      - blah2
+    container_name: blah2-host
+    depends_on:
+      - blah2_web
+      - blah2_api
+
+  tar1090:
+    restart: always
+    platform: linux/arm64/v8
+    image: ghcr.io/offworldlabs/tar1090-node:${TAR1090_V:-v0.2.0}
+    container_name: tar1090
+    hostname: tar1090
+    ports:
+      - "${TAR1090_PORT:-8078}:80"
+    networks:
+      - blah2
+    depends_on:
+      config-merger:
+        condition: service_completed_successfully
+    environment:
+      - TZ=${TZ:-UTC}
+      # readsb config - pulls from radar3
+      - READSB_DEVICE_TYPE=none
+      - READSB_NET_ENABLE=true
+      - READSB_NET_CONNECTOR=${READSB_NET_CONNECTOR:-radar3.retnode.com,30005,beast_in}
+      - READSB_LAT=${RECEIVER_LAT:-33.939182}
+      - READSB_LON=${RECEIVER_LON:--84.65191}
+      - READSB_ALT=${RECEIVER_ALT:-320}
+      - READSB_RX_LOCATION_ACCURACY=2
+      - READSB_STATS_RANGE=true
+      # tar1090 map config
+      - LAT=${RECEIVER_LAT:-33.939182}
+      - LONG=${RECEIVER_LON:--84.65191}
+      - TAR1090_DEFAULTCENTERLAT=${RECEIVER_LAT:-33.939182}
+      - TAR1090_DEFAULTCENTERLON=${RECEIVER_LON:--84.65191}
+      # adsb.lol proxy config
+      - ADSBLOL_ENABLED=${ADSBLOL_ENABLED:-true}
+      - RECEIVER_LAT=${RECEIVER_LAT:-33.939182}
+      - RECEIVER_LON=${RECEIVER_LON:--84.65191}
+      - ADSBLOL_RADIUS=${ADSBLOL_RADIUS:-40}
+      - PROXY_PORT=3005
+    tmpfs:
+      - /var/log:size=32M
+
+  adsb2dd:
+    restart: always
+    platform: linux/arm64/v8
+    image: ghcr.io/offworldlabs/adsb2dd:${ADSB2DD_V:-v0.1.3}
+    ports:
+      - "49155:49155"  # API port
+    networks:
+      - blah2
+    depends_on:
+      - tar1090
+    container_name: adsb2dd
+    environment:
+      - TZ=${TZ:-UTC}
+      # adsb2dd will read from tar1090 on the same network

--- a/staging/merge-config.sh
+++ b/staging/merge-config.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Manually merge config files for staging
+# Combines: default.yml → user.yml → forced.yml = config.yml
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETINA_NODE_DIR="$(dirname "$SCRIPT_DIR")"
+
+DEFAULT_YML="$RETINA_NODE_DIR/config/default.yml"
+FORCED_YML="$RETINA_NODE_DIR/config/forced.yml"
+USER_YML="$SCRIPT_DIR/config/user.yml"
+OUTPUT_YML="$SCRIPT_DIR/config/config.yml"
+
+echo "Merging configuration files..."
+echo "  Default: $DEFAULT_YML"
+echo "  User:    $USER_YML"
+echo "  Forced:  $FORCED_YML"
+echo "  Output:  $OUTPUT_YML"
+
+# Check dependencies
+if ! command -v python3 &>/dev/null; then
+  echo "Error: python3 not found"
+  exit 1
+fi
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+  echo "Error: PyYAML not installed. Install with: pip3 install pyyaml"
+  exit 1
+fi
+
+# Create merge script
+python3 - <<'PYTHON'
+import sys
+import yaml
+from pathlib import Path
+
+def deep_merge(base, override):
+    """Recursively merge override into base"""
+    for key, value in override.items():
+        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+# Read files
+default = yaml.safe_load(Path(sys.argv[1]).read_text())
+user = yaml.safe_load(Path(sys.argv[2]).read_text()) if Path(sys.argv[2]).exists() else {}
+forced = yaml.safe_load(Path(sys.argv[3]).read_text()) if Path(sys.argv[3]).exists() else {}
+
+# Merge: default → user → forced
+config = default.copy()
+deep_merge(config, user)
+deep_merge(config, forced)
+
+# Write output
+Path(sys.argv[4]).write_text(yaml.dump(config, default_flow_style=False, sort_keys=False))
+print(f"✓ Config merged successfully: {sys.argv[4]}")
+PYTHON "$DEFAULT_YML" "$USER_YML" "$FORCED_YML" "$OUTPUT_YML"

--- a/staging/setup.sh
+++ b/staging/setup.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Setup staging environment for retina-node on x86_64 server
+# Enables ARM64 container execution via QEMU userspace emulation
+set -euo pipefail
+
+echo "=== Retina Node Staging Setup ==="
+echo "Setting up ARM64 emulation on x86_64 host"
+echo ""
+
+# Check architecture
+ARCH=$(uname -m)
+if [ "$ARCH" != "x86_64" ]; then
+  echo "Warning: This script is designed for x86_64 hosts. Current: $ARCH"
+fi
+
+# Install QEMU and binfmt support
+echo "Installing QEMU for ARM64 emulation..."
+sudo apt-get update
+sudo apt-get install -y qemu-user-static binfmt-support
+
+# Register ARM64 binary format handlers
+echo "Registering ARM64 binary formats..."
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+# Verify ARM64 support
+echo ""
+echo "Verifying ARM64 support..."
+if docker run --rm --platform linux/arm64 arm64v8/alpine uname -m | grep -q aarch64; then
+  echo "✓ ARM64 emulation working"
+else
+  echo "✗ ARM64 emulation failed"
+  exit 1
+fi
+
+# Create staging directory structure
+echo ""
+echo "Creating staging directories..."
+mkdir -p config data/blah2/save data/blah2/test
+
+# Copy configuration templates
+if [ ! -f config/user.yml ]; then
+  echo "Creating default staging config..."
+  cat > config/user.yml <<'EOF'
+# Staging environment configuration
+# Pulls data from radar3.retnode.com production node
+
+location:
+  rx:
+    latitude: 33.939182
+    longitude: -84.65191
+    altitude: 320
+    name: "radar3-rx"
+  tx:
+    latitude: 33.939182
+    longitude: -84.331844
+    altitude: 650
+    name: "WXIA HDTV"
+
+# Note: Network IPs will be overridden by .env.staging
+# to point to public radar3 endpoints
+EOF
+fi
+
+# Create .env file
+if [ ! -f .env.staging ]; then
+  echo "Creating .env.staging..."
+  cat > .env.staging <<'EOF'
+# Staging environment variables
+# Run on x86_64 host with ARM64 emulation
+
+# Skip config-merger (use manual config)
+SKIP_CONFIG_MERGER=true
+
+# Override paths for staging
+CONFIG_DIR=./config
+DATA_DIR=./data
+MENDER_APP_DIR=./manifests
+MENDER_DATA_DIR=./manifests
+
+# Package versions (override these when testing new versions)
+BLAH2_V=v0.3.4
+TAR1090_V=v0.2.0
+ADSB2DD_V=v0.1.3
+CONFIG_MERGER_V=v0.3.3
+
+# Service ports (avoid conflicts with other services)
+BLAH2_WEB_PORT=49152
+BLAH2_HOST_PORT=8080
+TAR1090_PORT=8078
+
+# Location (radar3)
+RECEIVER_LAT=33.939182
+RECEIVER_LON=-84.65191
+RECEIVER_ALT=320
+TZ=America/New_York
+
+# ADS-B feed configuration
+# Point to radar3's public endpoints
+READSB_NET_CONNECTOR=radar3.retnode.com,30005,beast_in
+ADSBLOL_ENABLED=true
+ADSBLOL_RADIUS=40
+EOF
+fi
+
+echo ""
+echo "=== Setup Complete ==="
+echo ""
+echo "Next steps:"
+echo "1. Review and edit config/user.yml for your needs"
+echo "2. Update .env.staging with package versions to test"
+echo "3. Run: docker compose -f docker-compose.staging.yml --env-file .env.staging up -d"
+echo "4. Access services:"
+echo "   - blah2 UI: http://localhost:49152"
+echo "   - tar1090: http://localhost:8078"
+echo "   - adsb2dd: http://localhost:49155"

--- a/staging/smoke-test.sh
+++ b/staging/smoke-test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Smoke tests for staging environment
+# Verifies all services are healthy and responding
+
+set -euo pipefail
+
+FAILED=0
+
+test_endpoint() {
+  local name=$1
+  local url=$2
+  local expected=${3:-}
+
+  echo -n "Testing $name... "
+
+  if response=$(curl -sf --max-time 5 "$url" 2>&1); then
+    if [ -n "$expected" ]; then
+      if echo "$response" | grep -q "$expected"; then
+        echo "✓"
+      else
+        echo "✗ (unexpected response)"
+        FAILED=$((FAILED + 1))
+      fi
+    else
+      echo "✓"
+    fi
+  else
+    echo "✗ (connection failed)"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+test_json_endpoint() {
+  local name=$1
+  local url=$2
+  local jq_filter=$3
+  local min_value=${4:-0}
+
+  echo -n "Testing $name... "
+
+  if ! command -v jq &>/dev/null; then
+    echo "⚠ (jq not installed)"
+    return
+  fi
+
+  if response=$(curl -sf --max-time 5 "$url" 2>&1); then
+    if value=$(echo "$response" | jq -r "$jq_filter" 2>/dev/null); then
+      if [ "$value" -ge "$min_value" ] 2>/dev/null; then
+        echo "✓ (value: $value)"
+      else
+        echo "⚠ (value: $value, expected >= $min_value)"
+      fi
+    else
+      echo "✗ (invalid JSON)"
+      FAILED=$((FAILED + 1))
+    fi
+  else
+    echo "✗ (connection failed)"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo "=== Retina Node Staging Smoke Tests ==="
+echo ""
+
+# Check containers are running
+echo "Checking containers..."
+RUNNING=$(docker compose -f docker-compose.staging.yml ps --filter "status=running" -q | wc -l)
+EXPECTED=6  # blah2_api, blah2_web, blah2_host, tar1090, adsb2dd, (config-merger exits)
+if [ "$RUNNING" -ge $((EXPECTED - 1)) ]; then
+  echo "✓ $RUNNING/$EXPECTED containers running"
+else
+  echo "✗ Only $RUNNING/$EXPECTED containers running"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+echo "Testing web interfaces..."
+test_endpoint "blah2 web UI" "http://localhost:49152" "<!DOCTYPE html>"
+test_endpoint "blah2 host" "http://localhost:8080"
+test_endpoint "tar1090" "http://localhost:8078" "tar1090"
+
+echo ""
+echo "Testing APIs..."
+test_endpoint "blah2 API config" "http://localhost:3000/api/config"
+test_endpoint "adsb2dd API" "http://localhost:49155/api"
+
+echo ""
+echo "Testing data feeds..."
+test_json_endpoint "tar1090 aircraft" "http://localhost:8078/data/aircraft.json" ".aircraft | length" 0
+test_json_endpoint "adsb2dd targets" "http://localhost:49155/api" "keys | length" 0
+
+echo ""
+echo "Checking logs for errors..."
+ERRORS=$(docker compose -f docker-compose.staging.yml logs --since 5m 2>&1 | grep -ci "error" || true)
+if [ "$ERRORS" -eq 0 ]; then
+  echo "✓ No errors in recent logs"
+else
+  echo "⚠ Found $ERRORS error messages in logs (review manually)"
+fi
+
+echo ""
+echo "==================================="
+if [ $FAILED -eq 0 ]; then
+  echo "✓ All tests passed!"
+  exit 0
+else
+  echo "✗ $FAILED test(s) failed"
+  exit 1
+fi

--- a/staging/test-version.sh
+++ b/staging/test-version.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Quick script to test a specific package version
+# Usage: ./test-version.sh blah2 v0.3.5
+#        ./test-version.sh adsb2dd v0.1.4
+
+set -euo pipefail
+
+COMPONENT=${1:-}
+VERSION=${2:-}
+
+usage() {
+  cat <<EOF
+Usage: $0 <component> <version>
+
+Test a specific component version in staging.
+
+Components:
+  blah2      - blah2-arm package (BLAH2_V)
+  adsb2dd    - adsb2dd package (ADSB2DD_V)
+  tar1090    - tar1090 package (TAR1090_V)
+  config     - config-merger (CONFIG_MERGER_V)
+
+Examples:
+  $0 blah2 v0.3.5
+  $0 adsb2dd v0.1.4
+  $0 tar1090 v0.2.1
+
+This script:
+1. Updates .env.staging with the new version
+2. Pulls the new image
+3. Restarts affected services
+4. Shows logs for verification
+EOF
+  exit 1
+}
+
+if [ -z "$COMPONENT" ] || [ -z "$VERSION" ]; then
+  usage
+fi
+
+# Map component to env var
+case "$COMPONENT" in
+  blah2)
+    ENV_VAR="BLAH2_V"
+    SERVICES="blah2_api blah2_web blah2_host"
+    ;;
+  adsb2dd)
+    ENV_VAR="ADSB2DD_V"
+    SERVICES="adsb2dd"
+    ;;
+  tar1090)
+    ENV_VAR="TAR1090_V"
+    SERVICES="tar1090"
+    ;;
+  config)
+    ENV_VAR="CONFIG_MERGER_V"
+    SERVICES="config-merger"
+    ;;
+  *)
+    echo "Error: Unknown component '$COMPONENT'"
+    usage
+    ;;
+esac
+
+echo "Testing $COMPONENT $VERSION"
+echo ""
+
+# Update .env.staging
+if [ ! -f .env.staging ]; then
+  echo "Error: .env.staging not found. Run ./setup.sh first."
+  exit 1
+fi
+
+echo "1. Updating .env.staging..."
+if grep -q "^${ENV_VAR}=" .env.staging; then
+  sed -i.bak "s/^${ENV_VAR}=.*/${ENV_VAR}=${VERSION}/" .env.staging
+else
+  echo "${ENV_VAR}=${VERSION}" >> .env.staging
+fi
+rm -f .env.staging.bak
+echo "   Set ${ENV_VAR}=${VERSION}"
+
+# Pull new image
+echo ""
+echo "2. Pulling new image..."
+docker compose -f docker-compose.staging.yml --env-file .env.staging pull $SERVICES
+
+# Restart services
+echo ""
+echo "3. Restarting services..."
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --force-recreate $SERVICES
+
+# Show status
+echo ""
+echo "4. Service status..."
+docker compose -f docker-compose.staging.yml ps $SERVICES
+
+# Show logs
+echo ""
+echo "5. Recent logs (Ctrl-C to exit)..."
+sleep 2
+docker compose -f docker-compose.staging.yml logs -f --tail=50 $SERVICES


### PR DESCRIPTION
## Overview

Adds a staging environment to test retina-node deployments on x86_64 servers before deploying to production Raspberry Pi nodes.

## Motivation

Currently, changes to blah2-arm and adsb2dd are built via GitHub Actions and deployed directly to production Raspberry Pis via Mender. This PR adds a staging layer to catch integration bugs before production deployment.

## Architecture

- **Host**: x86_64 Hetzner server running Ubuntu
- **Emulation**: QEMU userspace emulation for ARM64 containers
- **Data Source**: Pulls real ADS-B data from radar3.retnode.com
- **Services Tested**: blah2-api, blah2-web, blah2-host, tar1090, adsb2dd
- **Not Tested**: blah2 core radar processing (requires SDR hardware)

## Features

### Automated Setup
- `setup.sh` - Install QEMU and configure ARM64 support
- `merge-config.sh` - Generate config.yml from defaults + overrides
- `docker-compose.staging.yml` - ARM64 container orchestration

### Testing Tools
- `test-version.sh` - Quick test of specific package versions
- `smoke-test.sh` - Automated health checks for all services
- Support for testing blah2, adsb2dd, tar1090, config-merger packages

### Configuration
- `config/user.yml` - Staging-specific config (radar3 location)
- `.env.staging` - Environment variables for package versions
- Merges with production default.yml and forced.yml

## Documentation

- **README.md** - Comprehensive setup and usage guide
- **QUICKSTART.md** - Quick command reference for common tasks

## Usage

### Initial Setup
```bash
cd staging
./setup.sh
./merge-config.sh
docker compose -f docker-compose.staging.yml --env-file .env.staging up -d
```

### Test New Version
```bash
./test-version.sh blah2 v0.3.5
./smoke-test.sh
```

### Access Services
- blah2 UI: http://localhost:49152
- tar1090: http://localhost:8078
- adsb2dd: http://localhost:49155/api

## Workflow Integration

### Before Production Deployment
1. Build packages via GitHub Actions
2. Test in staging: `./test-version.sh blah2 v0.3.5`
3. Run health checks: `./smoke-test.sh`
4. Visual verification in browser
5. If stable, deploy to production via Mender

## Performance

ARM64 emulation is 2-3x slower than native but sufficient for functional testing. Not suitable for load testing, but catches integration bugs effectively.

## Future Enhancements

- CI/CD to auto-deploy to staging on successful builds
- Automated visual regression testing
- Optional: Full ARM64 VM with Mender for testing deployment flow

## Testing Checklist

- [ ] Verify setup.sh installs QEMU correctly
- [ ] Confirm ARM64 containers start successfully
- [ ] Test tar1090 receives ADS-B from radar3
- [ ] Verify adsb2dd processes data
- [ ] Confirm web interfaces load correctly
- [ ] Run smoke-test.sh successfully

## Related

- Addresses need for pre-production testing environment
- Complements existing Mender deployment workflow
- Uses existing Hetzner infrastructure