### PR TITLE
20260604 - docker-compose for proper retina-spectrum beviour.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,10 +136,15 @@ services:
       - TZ=${TZ:-UTC}
 
   retina-spectrum:
-    restart: always
+    profiles: [spectrum]
+    restart: unless-stopped
     image: ghcr.io/offworldlabs/retina-spectrum:${SPECTRUM_V:-v0.1.0}
-    ports:
-      - "${SPECTRUM_PORT:-3020}:3020"
-    networks:
-      - blah2
+    network_mode: host
+    pid: "host"
+    privileged: true
+    volumes:
+      - /dev/shm:/dev/shm:rw
+      - /dev/bus/usb:/dev/bus/usb:rw
+      - /usr/local/lib/libsdrplay_api.so.3.15:/usr/local/lib/libsdrplay_api.so.3:ro
+    command: bash -c "pkill -9 -f sdrplay_apiService 2>/dev/null || true && sleep 2 && retina-spectrum --web-dir /web"
     container_name: retina-spectrum


### PR DESCRIPTION
## Summary

The existing `retina-spectrum` service definition was non-functional: it used
bridge networking with no device mounts, meaning it could not access the SDR
hardware. Its `ports: ["3020:3020"]` mapping also held host port 3020
permanently, blocking any properly-configured instance from starting.

This PR replaces it with a correctly-configured service gated behind a Docker
Compose profile so it never starts automatically alongside the radar stack.

## Changes

- `profiles: [spectrum]` — service is ignored by plain `docker compose up -d`;
  only activated explicitly by the GUI mode toggle
- `network_mode: host` — retina-spectrum binds port 3020 directly on the host,
  matching blah2's networking model
- `pid: "host"` + `privileged: true` — required for SDRplay API access
- USB and shm device mounts — same as blah2
- SDRplay library bind-mount — same path as blah2 (`libsdrplay_api.so.3.15`)
- `sdrplay_apiService` reset command on startup — mirrors blah2's
  `sdrplay-restart.sh` to ensure clean hardware handoff when switching modes
- `restart: unless-stopped` (was `always`) — won't auto-restart if deliberately
  stopped by the mode toggle