### PR TITLE
20260609 - restart: "no" on retina-spectrum.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
 
   retina-spectrum:
     profiles: [spectrum]
-    restart: unless-stopped
+    restart: "no"
     image: ghcr.io/offworldlabs/retina-spectrum:${SPECTRUM_V:-v0.1.0}
     network_mode: host
     pid: "host"


### PR DESCRIPTION
## Summary
- Move `retina-spectrum` to the `spectrum` profile so it is never started by a plain `docker compose up`
- Switch to `network_mode: host` and `pid: host` to match the hardware access model used by `blah2`; add proper USB, shared memory, and SDRplay library mounts with startup command that kills any stale `sdrplay_apiService`
- Change `restart: "no"` — if retina-spectrum crashes or encounters an SDR error it gives up the hardware rather than looping. The GUI is the only thing allowed to start it