### PR TITLE
20260616 - Update default gainReduction

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -5,7 +5,7 @@ capture:
     type: "RspDuo"
     agcSetPoint: -60
     bandwidthNumber: 0
-    gainReduction: 40 #20-59 dB, higher is less gain
+    gainReduction: [40, 40] #20-59 dB each, [reference, surveillance], higher is less gain
     lnaState: 4 #1-9, higher is more gain
     dabNotch: true
     rfNotch: true


### PR DESCRIPTION
# Update default gainReduction to a [reference, surveillance] pair

## Summary

- Updates `config/default.yml`'s `gainReduction` from a scalar (`40`) to a 2-element list (`[40, 40]`) to match blah2's new independent per-tuner RSPduo gain support.

## Why

blah2 now requires `gainReduction` to be `[tunerA, tunerB]` instead of one shared value (see the companion `blah2-arm` PR). `config-merger` ships `default.yml` as the base layer that every device's `config.yml` is built from, so it needs to match the new schema or the merged config will fail to parse against the new blah2 binary.

## Changes

- `config/default.yml` — `gainReduction: 40` → `gainReduction: [40, 40]`.
- `config/config.yml` (the local, gitignored standalone copy) was also updated for local dev consistency but isn't part of this commit since it isn't tracked.

## Risks

- **Must land and deploy together with the `blah2-arm` gain-reduction PR.** If this device's config still has the old scalar value when the new blah2 binary runs, `config["gainReduction"][0]` on a non-list YAML node will throw inside rapidyaml at blah2 startup. There's no backward-compatibility shim for the old format — this is a deliberate hard cut, made acceptable by being pre-launch with no fleet to keep in lockstep.
- The merge logic in `config-merger/script/merge_config.py` is a generic, type-agnostic deep merge, so this change carries low risk to the merge process itself.

## Test plan

- [ ] `config-merger`'s pytest suite (`config-merger/test/test_merge_config.py`) — not run in dev sandbox (no pytest available in that environment); no test in that suite references `gainReduction` specifically, so risk to existing coverage is low.
- [ ] Deploy alongside the new blah2 image in the same dev release and confirm `config.yml` on the device ends up with the list format after `config-merger` runs.
