### PR TITLE
Fix Mender artifact build: resolve RETINA_TRACKER_V before packaging

### DIFF
--- a/scripts/build_mender_artifact.sh
+++ b/scripts/build_mender_artifact.sh
@@ -60,6 +60,7 @@ sed -e 's/\${BLAH2_V:-\([^}]*\)}/\1/g' \
     -e 's/\${ADSB2DD_V:-\([^}]*\)}/\1/g' \
     -e 's/\${CONFIG_MERGER_V:-\([^}]*\)}/\1/g' \
     -e 's/\${SPECTRUM_V:-\([^}]*\)}/\1/g' \
+    -e 's/\${RETINA_TRACKER_V:-\([^}]*\)}/\1/g' \
     "${COMPOSE_FILE}" > "${MANIFEST_DIR}/docker-compose.yaml"
 
 SCRIPT_DIR="$(dirname "$0")/mender-state-scripts"


### PR DESCRIPTION
## Summary
`build_mender_artifact.sh`'s `sed` list resolves every other service's version variable (`BLAH2_V`, `TAR1090_V`, `ADSB2DD_V`, `CONFIG_MERGER_V`, `SPECTRUM_V`) into a literal image tag before handing the compose file to `gen_docker-compose`/`skopeo`, but missed `RETINA_TRACKER_V` when that service was added in #20.

## Why
Confirmed by actually running the build: `gen_docker-compose` extracts image references via raw sed and can't handle unresolved shell variables, so `skopeo` fails outright trying to pull `ghcr.io/offworldlabs/retina-tracker:${RETINA_TRACKER_V:-v0.1.1}` as a literal reference:
```
time="2026-07-21T09:07:13Z" level=fatal msg="Invalid source name docker://ghcr.io/offworldlabs/retina-tracker:${RETINA_TRACKER_V:-v0.1.1}: invalid reference format"
```
This blocks any Mender artifact build entirely, not just a cosmetic inconsistency — needed before a `-dev` tag can be pushed to test OTA.

## Test plan
- [x] Verified locally: piping `docker-compose.yml` through the updated sed chain resolves `retina-tracker`'s image to the literal `ghcr.io/offworldlabs/retina-tracker:v0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)