### PR TITLE
20260721 - Wire retina-tracker sidecar to blah2's fc and a tunable min_snr

### DIFF
--- a/config-merger/script/merge_config.py
+++ b/config-merger/script/merge_config.py
@@ -6,6 +6,8 @@ Designed to be run in both blah2 and blah2-api containers with baked-in configs.
 Merges default.yml + user.yml + forced.yml into config.yml.
 Also syncs the node_id field in user.yml from Mender device identity (/data/mender/node_id).
 Generates tar1090.env for tar1090-node if the tar1090 section exists in config.
+Generates retina-tracker.yaml for the retina-tracker sidecar if the
+retina_tracker section exists in config.
 
 Takes as inputs:
 1. Defaults directory - holds baked-in default.yml and forced.yml
@@ -20,6 +22,7 @@ Merge order (later overrides earlier):
 Outputs:
   - config.yml: Merged configuration for blah2
   - tar1090.env: Environment variables for tar1090-node
+  - retina-tracker.yaml: Config overrides for the retina-tracker sidecar
 """
 
 import yaml
@@ -98,6 +101,33 @@ def generate_env_file(config, output_dir):
                 print(f"Copied .env to {env_dest}")
         except Exception as e:
             print(f"Note: Could not copy to {env_dest}: {e}")
+
+
+def generate_retina_tracker_config(config, output_dir):
+    """Generate a config file for the retina-tracker sidecar from the merged
+    config's `retina_tracker` section.
+
+    retina_tracker.config.load_config() shallow-merges this per top-level
+    section (`default_config[key].update(loaded[key])`), so only the
+    overridden keys need to be present here - everything else falls back to
+    the package's own built-in defaults. All fields under `retina_tracker`
+    here are assumed to belong to retina-tracker's own `tracker` section;
+    revisit this mapping if fields for its other sections (`process_noise`,
+    `tracklet`, `adsb`, ...) are ever added to default.yml.
+    """
+    if 'retina_tracker' not in config:
+        print("No retina_tracker config found, skipping retina-tracker.yaml generation")
+        return
+
+    output_path = os.path.join(output_dir, 'retina-tracker.yaml')
+    print(f"Writing retina-tracker config to {output_path}")
+
+    # Write to temp file first, then atomic rename
+    temp_path = output_path + '.tmp.' + str(os.getpid())
+    with open(temp_path, 'w') as f:
+        yaml.dump({'tracker': config['retina_tracker']}, f, default_flow_style=False, sort_keys=False)
+    os.rename(temp_path, output_path)
+    print("retina-tracker.yaml generated successfully!")
 
 
 def migrate_gain_reduction(config):
@@ -238,6 +268,9 @@ def main():
 
         # Generate .env file for tar1090-node
         generate_env_file(config, os.path.dirname(output_config_path))
+
+        # Generate config file for the retina-tracker sidecar
+        generate_retina_tracker_config(config, os.path.dirname(output_config_path))
 
         print("Config merge completed successfully!")
         

--- a/config-merger/test/test_merge_config.py
+++ b/config-merger/test/test_merge_config.py
@@ -369,6 +369,11 @@ class TestConfigMerge(unittest.TestCase):
         self.assertIn('network', output)
         self.assertEqual(output['network']['node_id'], 'test-node')
 
+        # Verify retina-tracker.yaml was generated
+        tracker_yaml_path = os.path.join(self.config_dir, 'retina-tracker.yaml')
+        self.assertTrue(os.path.exists(tracker_yaml_path),
+                         "retina-tracker.yaml should be generated with actual config")
+
         # Verify tar1090.env was generated
         env_path = os.path.join(self.config_dir, 'tar1090.env')
         self.assertTrue(os.path.exists(env_path), "tar1090.env should be generated with actual config")
@@ -467,6 +472,57 @@ class TestConfigMerge(unittest.TestCase):
         self.assertIn('RECEIVER_LAT=37.7644', env_content)
         self.assertIn('RECEIVER_LON=-122.3954', env_content)
         self.assertIn('RECEIVER_ALT=23', env_content)
+
+    def test_retina_tracker_yaml_generated(self):
+        """Test that retina-tracker.yaml is generated when retina_tracker config exists"""
+        default_config = {
+            'process': {'detection': {'pfa': 0.001}},
+            'retina_tracker': {'min_snr': 7.0},
+        }
+        self.write_yaml(os.path.join(self.defaults_dir, 'default.yml'), default_config)
+        self.write_yaml(os.path.join(self.defaults_dir, 'forced.yml'), {})
+
+        self.run_merge()
+
+        tracker_yaml_path = os.path.join(self.config_dir, 'retina-tracker.yaml')
+        self.assertTrue(os.path.exists(tracker_yaml_path), "retina-tracker.yaml should be generated")
+
+        output = self.read_yaml(tracker_yaml_path)
+        self.assertEqual(output, {'tracker': {'min_snr': 7.0}})
+
+    def test_retina_tracker_yaml_not_generated_without_config(self):
+        """Test that retina-tracker.yaml is not generated when retina_tracker config is missing"""
+        default_config = {
+            'process': {'detection': {'pfa': 0.001}},
+            'network': {'ip': '0.0.0.0'},
+        }
+        self.write_yaml(os.path.join(self.defaults_dir, 'default.yml'), default_config)
+        self.write_yaml(os.path.join(self.defaults_dir, 'forced.yml'), {})
+
+        self.run_merge()
+
+        tracker_yaml_path = os.path.join(self.config_dir, 'retina-tracker.yaml')
+        self.assertFalse(os.path.exists(tracker_yaml_path),
+                          "retina-tracker.yaml should not be generated without retina_tracker config")
+
+    def test_retina_tracker_yaml_user_override(self):
+        """Test that user config overrides retina_tracker settings in retina-tracker.yaml"""
+        default_config = {
+            'retina_tracker': {'min_snr': 7.0},
+        }
+        user_config = {
+            'retina_tracker': {'min_snr': 4.5},
+        }
+        self.write_yaml(os.path.join(self.defaults_dir, 'default.yml'), default_config)
+        self.write_yaml(os.path.join(self.defaults_dir, 'forced.yml'), {})
+        self.write_yaml(os.path.join(self.config_dir, 'user.yml'), user_config)
+
+        self.run_merge()
+
+        tracker_yaml_path = os.path.join(self.config_dir, 'retina-tracker.yaml')
+        output = self.read_yaml(tracker_yaml_path)
+        self.assertEqual(output['tracker']['min_snr'], 4.5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/config/default.yml
+++ b/config/default.yml
@@ -102,3 +102,12 @@ tar1090:
   adsb_source: "192.168.8.183,30005,beast_in"  # External ADS-B feed (IP,PORT,PROTOCOL)
   adsblol_fallback: true
   adsblol_radius: 40
+
+# retina-tracker sidecar (github.com/offworldlabs/retina-tracker) config.
+# Unrelated to process.tracker above, which is blah2's own built-in tracker.
+retina_tracker:
+  # dB. Detections below this are discarded before tracking even begins -
+  # too high and the tracker silently never confirms a track no matter how
+  # good the search geometry is. Tune to this node's real noise floor
+  # (compare against SNR values from blah2_api's /api/detection).
+  min_snr: 7.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,9 @@ services:
     restart: always
     image: ghcr.io/offworldlabs/retina-tracker:${RETINA_TRACKER_V:-v0.1.1}
     network_mode: host
+    depends_on:
+      config-merger:
+        condition: service_completed_successfully
     # --tcp-host 127.0.0.1 (not the image's 0.0.0.0 default): network_mode
     # host means 0.0.0.0 would bind the real host interface, exposing the
     # ingest port to the LAN. retina-gui is always colocated on this same
@@ -163,6 +166,9 @@ services:
       python -m retina_tracker.track_detections
       --tcp --tcp-host 127.0.0.1 --tcp-port 30100
       -s /app/output/events.jsonl
+      -c /config/retina-tracker.yaml
+      --blah2-config /config/config.yml
     volumes:
       - ${DATA_DIR:-/data/retina-node}/retina-tracker/output:/app/output
+      - ${CONFIG_DIR:-/data/retina-node/config}:/config:ro
     container_name: retina-tracker


### PR DESCRIPTION
## Summary
- retina-tracker's sidecar had no way to see blah2's real `fc` or any config-driven detection threshold, so it always ran on the package's hardcoded defaults (`fc: 200MHz`, `min_snr: 7.0`) regardless of what the node is actually configured for.
- Mounts `CONFIG_DIR` into the `retina-tracker` container (read-only) and passes `--blah2-config /config/config.yml` so it picks up the real center frequency.
- Adds a new `retina_tracker` config section (`min_snr`, default `7.0` — unchanged default behavior) and generates `retina-tracker.yaml` from it in `merge_config.py`, mirroring the existing `tar1090.env` generation pattern. Passed to the sidecar via `-c`.
- Added `depends_on: config-merger` on the service so it never races a fresh config-merger run on boot.

`min_snr` is the load-bearing value: it's a hard pre-filter in retina-tracker's own code (`tracker.py`) — detections below it are discarded before tracking even begins. At the previous silent default of 7.0, a node whose real detections run lower (observed ~5-6dB on one desk node) could never confirm a single track. This PR wires the plumbing; per-node tuning of the value itself is exposed in a companion retina-gui PR.

## Test plan
- [x] `config-merger/test/test_merge_config.py`: 3 new tests (generated when section exists / not generated when absent / user override flows through) + updated `test_actual_config_files`. 18/19 pass (1 pre-existing failure unrelated to this change, confirmed present on clean `main`).
- [x] Verified live end-to-end on a desk node: rebuilt `retina-config-merger` locally, confirmed `retina-tracker.yaml` generation, confirmed the sidecar logs `Loaded config from /config/retina-tracker.yaml` and `Loaded center frequency ... MHz from /config/config.yml` on startup, confirmed via `/config/apply` (the real production route) that the full stack recreate picks everything up correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)