### PR TITLE
Disable blah2's built-in tracker by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -37,7 +37,11 @@ process:
     minDoppler: 15
     nCentroid: 6
   tracker:
-    enable: true
+    # blah2's own built-in tracker - superseded by the retina-tracker sidecar
+    # (see retina_tracker below), which is what's actually used. Left disabled
+    # so nothing runs its associate/promote loop or feeds its unused
+    # blah2-api /api/tracker endpoint.
+    enable: false
     initiate:
       M: 3
       N: 5


### PR DESCRIPTION
## Summary

- `process.tracker.enable` in `config/default.yml`: `true` → `false`.
- blah2's built-in tracker is redundant with the `retina-tracker` sidecar, which is what's actually used — `retina-tracker` does its own independent detection-to-track logic and never consumes blah2's tracker output (confirmed no reference to `process.tracker`/`network.ports.track` anywhere in `retina-tracker` or `retina-gui`'s `retina_tracker_client.py`).
- Leaving it enabled means every node runs a second, unused tracking implementation for nothing — including a now-fixed unbounded-memory-growth bug in blah2's own tracker (see [blah2-arm#48](https://github.com/offworldlabs/blah2-arm/pull/48)), but the cost isn't worth paying even with that fixed.
- Checked for UI impact: blah2-web's dashboard has no "Tracker" display tile in its real feature set — `/api/tracker` only appears as a raw link under a collapsed dev-only "API" debug section, so nothing user-facing goes blank.

## Test plan

- [x] Verified against the config-merger's own pytest suite: 18/19 pass (1 pre-existing, unrelated failure — a stale test expecting old San Francisco lat/lon defaults that don't match the current default location).
- [x] Deployed and confirmed live on a real test node: `config-merger` regenerates `config.yml` with `tracker.enable: false`, `blah2` restarts cleanly, and `blah2-api`'s `/api/tracker` returned byte-for-byte identical responses 8 seconds apart post-restart — direct evidence blah2 stopped producing tracker output entirely, not just a config flag that looks right on paper.
- [x] All other containers on the test node were unaffected (untouched uptime, `free -m` stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)