### PR TITLE
Fix test_actual_config_files: read expectations from default.yml

### DIFF
--- a/config-merger/test/test_merge_config.py
+++ b/config-merger/test/test_merge_config.py
@@ -382,12 +382,23 @@ class TestConfigMerge(unittest.TestCase):
         with open(env_path) as f:
             env_content = f.read()
 
-        # Check expected values from default.yml (San Francisco location)
-        self.assertIn('RECEIVER_LAT=37.7644', env_content)
-        self.assertIn('RECEIVER_LON=-122.3954', env_content)
-        self.assertIn('RECEIVER_ALT=23', env_content)
-        self.assertIn('ADSBLOL_ENABLED=true', env_content)
-        self.assertIn('ADSBLOL_RADIUS=40', env_content)
+        # Read the expected values from default.yml rather than duplicating
+        # them. This test's purpose is that the merger propagates the real
+        # config into tar1090.env — not that the config holds any particular
+        # site. Hardcoding them meant 64ff0c9, which deliberately replaced the
+        # site-specific defaults with generic placeholders, silently broke this.
+        defaults = self.read_yaml(default_yml_path)
+        rx = defaults['location']['rx']
+        tar1090 = defaults.get('tar1090', {})
+
+        self.assertIn(f"RECEIVER_LAT={rx['latitude']}", env_content)
+        self.assertIn(f"RECEIVER_LON={rx['longitude']}", env_content)
+        self.assertIn(f"RECEIVER_ALT={rx['altitude']}", env_content)
+        self.assertIn(
+            f"ADSBLOL_ENABLED={'true' if tar1090.get('adsblol_fallback') else 'false'}",
+            env_content,
+        )
+        self.assertIn(f"ADSBLOL_RADIUS={tar1090['adsblol_radius']}", env_content)
 
     def test_tar1090_env_with_adsb_source(self):
         """Test that READSB_NET_CONNECTOR is included in .env when configured"""


### PR DESCRIPTION
Part of [86cb4jfk7](https://app.clickup.com/t/86cb4jfk7). This repo's suite has never run in CI; running it gives **18 passed, 1 failed**.

## Root cause

`test_actual_config_files` runs the merger against the real `config/` directory, then asserted hardcoded San Francisco coordinates:

```python
# Check expected values from default.yml (San Francisco location)
self.assertIn('RECEIVER_LAT=37.7644', env_content)
```

`64ff0c9` *(2026-03-23, "Replace site-specific defaults with generic placeholders")* deliberately changed those to Greenwich. The config change was correct; the test duplicated data it did not own and was never updated. It has failed for five months without anyone knowing.

## The fix

The test's purpose, per its own docstring, is *"merge with actual config files from retina-node repo"* — that the merger propagates the real config into `tar1090.env`. The particular coordinates are incidental, so it now reads them from `default.yml`.

Its sibling `test_tar1090_env_uses_location_rx` keeps its literal `37.7644` — that test **writes its own** `default.yml`, so those are its fixture data rather than a claim about the repo's config. That difference is exactly why one broke and one did not.

## Verification, both directions

Updating the numbers would have made the test pass while leaving it just as brittle, so the fix was checked against both failure modes:

- Changed `default.yml`'s location to arbitrary values → **test still passes** (it no longer duplicates config data)
- Broke the merger so it stops propagating latitude → **test still fails** (it still tests what it claims to)

Suite: **19 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZcazeseXVpu8XrYA2tE1V