### PR TITLE
20260813 - Bump config-merger pin to v0.4.3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   config-merger:
     restart: "no"  # Run once and exit
-    image: ghcr.io/offworldlabs/retina-config-merger:${CONFIG_MERGER_V:-v0.3.17}
+    image: ghcr.io/offworldlabs/retina-config-merger:${CONFIG_MERGER_V:-v0.4.3.0}
     volumes:
       - ${CONFIG_DIR:-/data/retina-node/config}:/data/retina-node/config
       - ${MENDER_COMPOSE_DIR:-/data/mender-docker-compose}:/data/mender-docker-compose


### PR DESCRIPTION
## Problem

`CONFIG_MERGER_V` has defaulted to `v0.3.17` since release v0.4.0 — six releases ago — while every other image pin moved on. Because `scripts/build_mender_artifact.sh` sed-strips `${VAR:-default}` down to the default literal, that default is exactly what ships to devices. It is not a fallback; it is the shipped value.

CI has built and published a fresh merger image on every release the whole time (`retina-config-merger:v0.4.3.0` exists in ghcr right now). Nothing consumed any of them, so nothing appeared broken.

`v0.3.17` also isn't a tag in this repo — tags jump v0.3.16 → v0.4.0 — so the pinned image came from a manual `workflow_dispatch` build and maps to no commit.

## Impact

Verified by extracting the files from the `v0.3.17` image running on both Jonathan nodes and diffing against `main`. Five merged changes have never reached a node:

**Script** (both functions absent from the deployed image):
- `generate_retina_tracker_config` (1936173) — writes `retina-tracker.yaml`. Without it the GUI's Minimum SNR field is a silent no-op: nodes fall back to the tracker image's own default, or keep a stale `retina-tracker.yaml` forever.
- `migrate_gain_reduction` (e96c56d) — scalar → `[reference, surveillance]` migration.

**Baked-in `config/default.yml`** (the image bakes this in too):
- `gainReduction: 40` → `[40, 40]` (653d305)
- `process.tracker.enable: true` → `false` (46f7bc2)
- new `retina_tracker: min_snr: 7.0` section (1936173)

Per-tuner gain is therefore stranded twice over: nodes still carry the scalar default *and* lack the migration that would repair it.

## Change

One line — bump the default to `v0.4.3.0`, the newest published merger image, which contains all of the above.

## Note for the next release

This pin is only ever correct for one release. The merger image is published under the retina-node release tag, so `CONFIG_MERGER_V` must be bumped to the version being cut, in the same commit as the other five pins. `v0.4.3.0` here drains the backlog; it does not make the pin permanently correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)