### PR TITLE
Run the config-merger test suite in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,14 @@ jobs:
 
       - name: Dead code
         run: pre-commit run --all-files --show-diff-on-failure
+
+      # This repo has no Python packaging, so the config-merger's dependencies
+      # are named here directly. They mirror config-merger/Dockerfile, which
+      # installs the same two unpinned — keep the two in step.
+      - run: pip install pyyaml mergedeep 'pytest>=8.0'
+
+      # Tests live under config-merger/test/, not tests/, so the path is
+      # explicit. This suite had never run in CI until 86cb4jfk7; the failure
+      # it now protects against had gone unnoticed for five months.
+      - name: Tests
+        run: pytest config-merger/test/


### PR DESCRIPTION
Second half of [86cb4jfk7](https://app.clickup.com/t/86cb4jfk7). [#27](https://github.com/offworldlabs/retina-node/pull/27) fixed the failing test; this makes the suite load-bearing.

## Why

19 tests have existed here and never run in CI. That is precisely how `test_actual_config_files` came to assert San Francisco coordinates for **five months** after `64ff0c9` deliberately replaced the site-specific defaults with generic placeholders. The config change was correct; nothing was watching the test that disagreed.

## The change

```yaml
      - run: pip install pyyaml mergedeep 'pytest>=8.0'
      - name: Tests
        run: pytest config-merger/test/
```

Two things worth noting for review:

**Dependencies are named directly.** This repo has no `requirements.txt` or `pyproject.toml`, so there is nowhere else to put them. They mirror `config-merger/Dockerfile`, which installs `pyyaml mergedeep` unpinned — those two lines now need to stay in step, and the workflow comment says so.

**The test path is explicit**, because tests live under `config-merger/test/` rather than `tests/`.

## Verification

Ran the exact CI commands in a clean venv from a pristine checkout: **19 passed**, exit 0.

Also checked the failure mode that would matter most here: `pytest` against a path that does not exist exits **4**, not 0. A mistyped path fails the step rather than collecting nothing and reporting success — which, given this repo just spent five months not noticing a broken test, seemed worth confirming rather than assuming.

Adds about 2 seconds to the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZcazeseXVpu8XrYA2tE1V