### PR TITLE
20260816 - Resolve the telemetry image tag when building the artifact

### DIFF
--- a/scripts/build_mender_artifact.sh
+++ b/scripts/build_mender_artifact.sh
@@ -61,7 +61,20 @@ sed -e 's/\${BLAH2_V:-\([^}]*\)}/\1/g' \
     -e 's/\${CONFIG_MERGER_V:-\([^}]*\)}/\1/g' \
     -e 's/\${SPECTRUM_V:-\([^}]*\)}/\1/g' \
     -e 's/\${RETINA_TRACKER_V:-\([^}]*\)}/\1/g' \
+    -e 's/\${TELEMETRY_V:-\([^}]*\)}/\1/g' \
     "${COMPOSE_FILE}" > "${MANIFEST_DIR}/docker-compose.yaml"
+
+# Every image tag must be a literal by this point. The list above is by hand,
+# so adding a service to docker-compose.yml without adding its clause here
+# leaves a ${VAR:-default} that skopeo receives as a literal tag — the artifact
+# either fails to build or installs a service that can never start. Cheaper to
+# fail here, with the name of the variable that was missed.
+if unresolved=$(grep -nE '^\s+image:.*\$\{' "${MANIFEST_DIR}/docker-compose.yaml"); then
+    echo "Error: unresolved image tag variables in the generated manifest:" >&2
+    echo "${unresolved}" >&2
+    echo "Add a matching -e clause above for each." >&2
+    exit 1
+fi
 
 SCRIPT_DIR="$(dirname "$0")/mender-state-scripts"
 


### PR DESCRIPTION
Adding retina-telemetry to `docker-compose.yml` was not enough to ship it.

## The bug

The artifact build resolves image tags with **one hand-written sed clause per variable**, and `TELEMETRY_V` had none. The generated manifest kept a literal:

```
image: ghcr.io/offworldlabs/retina-telemetry:${TELEMETRY_V:-v0.1.0}
```

Which is exactly what the comment above that block warns about:

> gen_docker-compose uses raw sed to extract image names and **cannot handle unresolved shell variables**

`skopeo` receives `${TELEMETRY_V:-v0.1.0}` as a tag. The release either fails there, or produces an artifact whose telemetry service can never start on a node.

## Why nothing caught it

The compose file is valid. `docker compose config` resolves the variable correctly. The same service block ran on two live nodes against production. The defect isn't in the compose file at all — it's in a *transformation* of it that enumerates its variables by hand, in another file, with no test.

## The fix

The seventh clause, plus a guard that removes the need to remember an eighth: every image line in the generated manifest must be a literal, and the build fails naming the variable that was missed.

Verified against the merged `docker-compose.yml`:

| | before | after |
|---|---|---|
| image tags resolved | 9 of 10 | **10 of 10** |
| guard on the old six-clause build | — | exits 1, printing line 178 and the variable |
| runtime `${}` refs preserved | — | 35, untouched |

Runtime variables are deliberately left alone and still resolved from `.env` at deploy time — the check reads `image:` lines only. `bash -n` clean; generated manifest parses as YAML with all 10 services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)